### PR TITLE
support workdir in matcher.FileMatcher{}

### DIFF
--- a/examples/commander.yaml
+++ b/examples/commander.yaml
@@ -28,5 +28,7 @@ tests:
 
   it should match file output:
     command: printf "line one\nline two"
+    config:
+      dir: examples/
     stdout:
-      file: ../../examples/_fixtures/output.txt
+      file: _fixtures/output.txt

--- a/pkg/matcher/matcher.go
+++ b/pkg/matcher/matcher.go
@@ -2,12 +2,14 @@ package matcher
 
 import (
 	"fmt"
+	"io/ioutil"
+	"log"
+	"path/filepath"
+	"strings"
+
 	"github.com/antchfx/xmlquery"
 	"github.com/pmezard/go-difflib/difflib"
 	"github.com/tidwall/gjson"
-	"io/ioutil"
-	"log"
-	"strings"
 )
 
 const (
@@ -29,7 +31,7 @@ const (
 var ReadFile = ioutil.ReadFile
 
 // NewMatcher creates a new matcher by type
-func NewMatcher(matcher string) Matcher {
+func NewMatcher(matcher string, workdir string) Matcher {
 	switch matcher {
 	case Text:
 		return TextMatcher{}
@@ -44,7 +46,9 @@ func NewMatcher(matcher string) Matcher {
 	case XML:
 		return XMLMatcher{}
 	case File:
-		return FileMatcher{}
+		return FileMatcher{
+			workdir: workdir,
+		}
 	default:
 		panic(fmt.Sprintf("Validator '%s' does not exist!", matcher))
 	}
@@ -252,10 +256,11 @@ to be equal to
 // FileMatcher matches output captured from stdout or stderr
 // against the contents of a file
 type FileMatcher struct {
+	workdir string
 }
 
 func (m FileMatcher) Match(got interface{}, expected interface{}) MatcherResult {
-	expectedText, err := ReadFile(expected.(string))
+	expectedText, err := ReadFile(filepath.Join(m.workdir, expected.(string)))
 	if err != nil {
 		panic(err.Error())
 	}

--- a/pkg/matcher/matcher_test.go
+++ b/pkg/matcher/matcher_test.go
@@ -1,23 +1,31 @@
 package matcher
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_NewMatcher_Text(t *testing.T) {
-	got := NewMatcher(Text)
+	got := NewMatcher(Text, "")
 	assert.IsType(t, TextMatcher{}, got)
 }
 
 func Test_NewMatcher_Contains(t *testing.T) {
-	got := NewMatcher(Contains)
+	got := NewMatcher(Contains, "")
 	assert.IsType(t, ContainsMatcher{}, got)
 }
 
 func Test_NewMatcher_Equal(t *testing.T) {
-	got := NewMatcher(Equal)
+	got := NewMatcher(Equal, "")
 	assert.IsType(t, EqualMatcher{}, got)
+}
+
+func Test_NewMatcher_File(t *testing.T) {
+	workdir := "/foo/bar"
+	got := NewMatcher(File, workdir)
+	assert.IsType(t, FileMatcher{}, got)
+	assert.Equal(t, workdir, got.(FileMatcher).workdir)
 }
 
 func TestTextMatcher_Validate(t *testing.T) {
@@ -35,7 +43,7 @@ func TestNewMatcher_Fail(t *testing.T) {
 		assert.NotNil(t, r)
 	}()
 
-	_ = NewMatcher("no")
+	_ = NewMatcher("no", "")
 }
 
 func TestTextMatcher_ValidateFails(t *testing.T) {
@@ -73,7 +81,7 @@ func TestContainsMatcher_MatchFail(t *testing.T) {
 }
 
 func TestNewMatcher_NotContains(t *testing.T) {
-	m := NewMatcher(NotContains)
+	m := NewMatcher(NotContains, "")
 	assert.IsType(t, NotContainsMatcher{}, m)
 }
 
@@ -125,7 +133,7 @@ func TestXMLMatcher_DoesNotFindPath(t *testing.T) {
 }
 
 func TestXMLMatcher_MatchArray(t *testing.T) {
-	m := NewMatcher(XML)
+	m := NewMatcher(XML, "")
 	html := "<books><book>test1</book><book>test2</book></books>"
 
 	r := m.Match(html, map[string]string{"/books": "test1test2"})
@@ -169,7 +177,7 @@ func TestJSONMatcher_MatchArray(t *testing.T) {
 }
 
 func TestJSONMatcher_DoesNotMatch(t *testing.T) {
-	m := NewMatcher(JSON)
+	m := NewMatcher(JSON, "")
 	r := m.Match(`{"book": "another"}`, map[string]string{"book": "test"})
 
 	diff := `Expected json path "book" with result


### PR DESCRIPTION
Fixes #153 

Hey @SimonBaeumer,

I found a bit of what I consider a bug today with `file` assertion. Currently we aren't respecting the working directory for opening files. I opened this quick fix, for right now. If you could take a look that would be great.

I'm currently working on adding a `--workdir` flag so `workdir` can be set from the command line as well. This is a little bit more involved than I thought. I plan to rewrite `runtime.Validate` to get the `Matcher` a bit easier, rather than having pass `test.Command.Dir` through multiple `functions`. I also plan on manipulating `test_command.go`, to make passing command line args a bit easier. 

I'll probably be opening the branch off of this one, since I don't quite know my timeline on what I mentioned above. I mainly just wanted to get this fix in.

Cheers

## Checklist

 - [x] Added unit / integration tests for windows, macOS and Linux? 
 - [ ] Added a changelog entry in [CHANGELOG.md](https://github.com/commander-cli/commander/blob/master/CHANGELOG.md)?
 - [ ] Updated the documentation ([README.md](https://github.com/commander-cli/commander/blob/master/README.md), [docs](https://github.com/commander-cli/commander/blob/master/docs))?
 - [x] Does your change work on `Linux`, `Windows` and `macOS`?