### PR TITLE
Check interface implementation at compile time

### DIFF
--- a/pkg/matcher/matcher.go
+++ b/pkg/matcher/matcher.go
@@ -24,6 +24,16 @@ const (
 	File        = "file"
 )
 
+var (
+	_ Matcher = (*TextMatcher)(nil)
+	_ Matcher = (*ContainsMatcher)(nil)
+	_ Matcher = (*EqualMatcher)(nil)
+	_ Matcher = (*NotContainsMatcher)(nil)
+	_ Matcher = (*JSONMatcher)(nil)
+	_ Matcher = (*XMLMatcher)(nil)
+	_ Matcher = (*FileMatcher)(nil)
+)
+
 // The function used to open files when necessary for matching
 // Allows the file IO to be overridden during tests
 var ReadFile = ioutil.ReadFile

--- a/pkg/runtime/docker_executor.go
+++ b/pkg/runtime/docker_executor.go
@@ -15,6 +15,8 @@ import (
 	"time"
 )
 
+var _ Executor = (*DockerExecutor)(nil)
+
 // DockerExecutor executes the test inside a docker container
 type DockerExecutor struct {
 	Image        string // Image which is started to execute the test

--- a/pkg/runtime/local_executor.go
+++ b/pkg/runtime/local_executor.go
@@ -9,6 +9,8 @@ import (
 	"github.com/commander-cli/cmd"
 )
 
+var _ Executor = (*LocalExecutor)(nil)
+
 // LocalExecutor will be used to execute tests on the local host
 type LocalExecutor struct {
 }

--- a/pkg/runtime/ssh_executor.go
+++ b/pkg/runtime/ssh_executor.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 )
 
+var _ Executor = (*SSHExecutor)(nil)
+
 // SSHExecutor
 type SSHExecutor struct {
 	Host         string


### PR DESCRIPTION
This PR checks if interfaces are implemented on given structs at compile time.

## Checklist

 - [x] Added unit / integration tests for windows, macOS and Linux? 
 - [x] Added a changelog entry in [CHANGELOG.md](https://github.com/commander-cli/commander/blob/master/CHANGELOG.md)?
 - [x] Updated the documentation ([README.md](https://github.com/commander-cli/commander/blob/master/README.md), [docs](https://github.com/commander-cli/commander/blob/master/docs))?
 - [x] Does your change work on `Linux`, `Windows` and `macOS`?