### PR TITLE
fix-deploy-job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,8 +90,8 @@ jobs:
       - image: circleci/golang:1.16
     steps:
       - checkout
-      - run: go get -u github.com/tcnksm/ghr
       - run: make release
+      - run: go get -u github.com/tcnksm/ghr
       - run:
           name: Publish release
           command: ghr $GIT_RELEASE_TAG release/


### PR DESCRIPTION
In go [`1.16`](https://golang.org/doc/go1.16#go-command) `go build` no longer modifies go.mod or go.sum. Thus why we now have the error.

As shown in the last [deploy failing CI](https://app.circleci.com/pipelines/github/commander-cli/commander/90/workflows/ab187d0b-bde6-4489-8467-392f111ad562/jobs/343).  It appears we've been cluttering our go.mod file for some time. The change simply go gets `ghr` after we make our release.

Sorry for my confusion #173.  

## Checklist

 - [ ] Added unit / integration tests for windows, macOS and Linux? 
 - [ ] Added a changelog entry in [CHANGELOG.md](https://github.com/commander-cli/commander/blob/master/CHANGELOG.md)?
 - [ ] Updated the documentation ([README.md](https://github.com/commander-cli/commander/blob/master/README.md), [docs](https://github.com/commander-cli/commander/blob/master/docs))?
 - [ ] Does your change work on `Linux`, `Windows` and `macOS`?