### PR TITLE
Move examples to UsageText

### DIFF
--- a/cmd/commander/commander.go
+++ b/cmd/commander/commander.go
@@ -45,7 +45,7 @@ func createCliApp() *cli.App {
 
 func createTestCommand() cli.Command {
 	return cli.Command{
-		Name: "test",
+		Name:  "test",
 		Usage: "Execute cli app tests",
 		UsageText: `Execute cli app tests
 

--- a/cmd/commander/commander.go
+++ b/cmd/commander/commander.go
@@ -46,7 +46,8 @@ func createCliApp() *cli.App {
 func createTestCommand() cli.Command {
 	return cli.Command{
 		Name: "test",
-		Usage: `Execute cli app tests
+		Usage: "Execute cli app tests",
+		UsageText: `Execute cli app tests
 
 By default it will use the commander.yaml from your current directory.
 Tests are always executed in alphabetical order.


### PR DESCRIPTION
The description of the `test` command was too verbose for  the `--help` output on the root command.
This moves the Usage to UsageText which only prints on `commander test --help`.


## Checklist

 - [ ] Added unit / integration tests for windows, macOS and Linux? 
 - [ ] Added a changelog entry in [CHANGELOG.md](https://github.com/commander-cli/commander/blob/master/CHANGELOG.md)?
 - [ ] Updated the documentation ([README.md](https://github.com/commander-cli/commander/blob/master/README.md), [docs](https://github.com/commander-cli/commander/blob/master/docs))?
 - [ ] Does your change work on `Linux`, `Windows` and `macOS`?