### PR TITLE
Fix up release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,8 +88,8 @@ jobs:
       - image: circleci/golang:1.16
     steps:
       - checkout
+      - run: go install github.com/tcnksm/ghr@v0.14.0
       - run: make release
-      - run: go get -u github.com/tcnksm/ghr
       - run:
           name: Publish release
           command: ghr $GIT_RELEASE_TAG release/

--- a/Makefile
+++ b/Makefile
@@ -105,10 +105,6 @@ release-darwin-amd64:
 	$(info INFO: Starting build $@)
 	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags "-X main.version=$(GIT_RELEASE_TAG) -s -w" -o release/$(cmd)-darwin-amd64 $(exe)
 
-release-darwin-386:
-	$(info INFO: Starting build $@)
-	CGO_ENABLED=0 GOOS=darwin GOARCH=386 go build -ldflags "-X main.version=$(GIT_RELEASE_TAG) -s -w" -o release/$(cmd)-darwin-386 $(exe)
-
 release-windows-amd64:
 	$(info INFO: Starting build $@)
 	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags "-X main.version=$(GIT_RELEASE_TAG) -s -w" -o release/$(cmd)-windows-amd64.exe $(exe)
@@ -117,4 +113,4 @@ release-windows-386:
 	$(info INFO: Starting build $@)
 	CGO_ENABLED=0 GOOS=windows GOARCH=386 go build -ldflags "-X main.version=$(GIT_RELEASE_TAG) -s -w" -o release/$(cmd)-windows-386.exe $(exe)
 
-release: release-amd64 release-arm release-386 release-darwin-amd64 release-darwin-386 release-windows-amd64 release-windows-386
+release: release-amd64 release-arm release-386 release-darwin-amd64 release-windows-amd64 release-windows-386


### PR DESCRIPTION
switch ghr install over to go install to avoid chnaging of go.mod and remove darwin/386 build as [go 1.15 dropped support](https://go.dev/doc/go1.15#darwin)

Fixes #

## Checklist

 - [ ] Added unit / integration tests for windows, macOS and Linux? 
 - [ ] Added a changelog entry in [CHANGELOG.md](https://github.com/commander-cli/commander/blob/master/CHANGELOG.md)?
 - [ ] Updated the documentation ([README.md](https://github.com/commander-cli/commander/blob/master/README.md), [docs](https://github.com/commander-cli/commander/blob/master/docs))?
 - [ ] Does your change work on `Linux`, `Windows` and `macOS`?