### PR TITLE
Remove chocolate go install as it already exists

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,6 @@ jobs:
     steps:
       - checkout
       - run: choco install make
-      - run: choco install golang --version 1.16
       - run: make test
 
   integration:
@@ -79,7 +78,6 @@ jobs:
       - checkout
       - run: choco install make
       - run: choco install curl
-      - run: choco install golang --version 1.16
       - run: Invoke-WebRequest -Uri "https://github.com/commander-cli/commander/releases/download/v2.4.0/commander-darwin-amd64" -OutFile "C:\Windows\system32\commander.exe"
       - run: make integration-windows
 


### PR DESCRIPTION
Fixes #

## Checklist

 - [ ] Added unit / integration tests for windows, macOS and Linux? 
 - [ ] Added a changelog entry in [CHANGELOG.md](https://github.com/commander-cli/commander/blob/master/CHANGELOG.md)?
 - [ ] Updated the documentation ([README.md](https://github.com/commander-cli/commander/blob/master/README.md), [docs](https://github.com/commander-cli/commander/blob/master/docs))?
 - [ ] Does your change work on `Linux`, `Windows` and `macOS`?