### PR TITLE
Update go get installation cmd to go install

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ For more information take a look at the [quick start](#quick-start), the [exampl
 Probably the easiest way to install `commander` is by using `go get` to download and install it in one simple command:
 
 ```bash
-go get github.com/commander-cli/commander/v2/cmd/commander
+go install github.com/commander-cli/commander/v2/cmd/commander@latest
 ```
 
 This works on any OS, as long as go is installed. If go is not installed on your system, follow one of the methods below.


### PR DESCRIPTION
Fixes #
README Installation with Go Fix: 
`go get` is not supported for external modules, `go install` is now the cmd

## Checklist

 - [ ] Added unit / integration tests for windows, macOS and Linux? 
 - [ ] Added a changelog entry in [CHANGELOG.md](https://github.com/commander-cli/commander/blob/master/CHANGELOG.md)?
 - [X] Updated the documentation ([README.md](https://github.com/commander-cli/commander/blob/master/README.md), [docs](https://github.com/commander-cli/commander/blob/master/docs))?
 - [ ] Does your change work on `Linux` and `Windows`?
- [X] Does your change work on `macOS`?

I believe the first 2 checklist items are not applicable and I am unable to test on Linux / Windows that `go install github.com/commander-cli/commander/v2/cmd/commander@latest` installs commander.